### PR TITLE
Accepts gitlab@ as user

### DIFF
--- a/lib/git-issues/providers/gitlab.rb
+++ b/lib/git-issues/providers/gitlab.rb
@@ -6,7 +6,7 @@ require 'gitlab'
 class RepoProvider::Gitlab
 
   URL_PATTERNS = [
-    /^(ssh:\/\/)?git@(?<host>[^:]*):(?<user>[^\/]+)\/(?<repo>.+)\.git$/
+    /^(ssh:\/\/)?git(lab)?@(?<host>[^:]*):(?<user>[^\/]+)\/(?<repo>.+)\.git$/
   ]
 
   def self.get_repo url


### PR DESCRIPTION
I believe archlinux AUR pkg has this as default user. 
Now it recognizes it as gitlab repo.
